### PR TITLE
refactor(terraform): replace null_resource with external data source for cluster creation

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -73,20 +73,10 @@ locals {
     )
   )
 
-  # Path to the cluster output file
-  output_file = "${path.module}/cluster_output.txt"
-
-  # Safely read and parse the output file
-  raw_output = data.local_file.cluster_output.content
-
-
-  # Split into lines and remove empty ones
-  output_lines = compact(split("\n", local.raw_output))
-
-  # Parse output file into key-value map
+  # Update the output_map to use the external data source
   output_map = {
-    for line in local.output_lines :
-    split("::", line)[0] => split("::", line)[1]
-    if length(split("::", line)) == 2
+    "CLUSTER_ID"    = data.external.create_cluster.result.cluster_id
+    "CLUSTER_TOKEN" = data.external.create_cluster.result.cluster_token
+    "TENANT_NAME"   = data.external.create_cluster.result.tenant_name
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,13 @@
-resource "null_resource" "create_cluster" {
-  triggers = {
-    cluster_name  = var.cluster_name
-    cluster_type  = var.cluster_type
-    always_update = var.always_update ? timestamp() : "initial"
-  }
+# Replace the null_resource and local_file data source with external data source
+data "external" "create_cluster" {
+  program = ["bash", "${path.module}/scripts/setup_truefoundry_cluster.sh"]
 
-  provisioner "local-exec" {
-    command = <<-EOT
-      mkdir -p ${dirname(local.output_file)}
-      touch ${local.output_file}
-      bash ${path.module}/scripts/setup_truefoundry_cluster.sh \
-        '${var.control_plane_url}' \
-        '${var.tfy_api_key}' \
-        '${var.cluster_name}' \
-        '${var.cluster_type}' \
-        '${base64encode(local.provider_config)}' \
-        '${local.output_file}'
-    EOT
+  query = {
+    control_plane_url      = var.control_plane_url
+    api_key                = var.tfy_api_key
+    cluster_name           = var.cluster_name
+    cluster_type           = var.cluster_type
+    provider_config_base64 = base64encode(local.provider_config)
+    always_update          = var.always_update ? timestamp() : "initial"
   }
-}
-
-# Add data source to read the output file after creation
-data "local_file" "cluster_output" {
-  depends_on = [null_resource.create_cluster]
-  filename   = local.output_file
 }


### PR DESCRIPTION
This change improves the Terraform configuration by replacing the
null_resource and local_file data source with an external data source.
This refactor enhances the process by directly capturing the output
from the external script, eliminating the need for intermediate files
and simplifying the data flow. The script now reads input via stdin
and outputs JSON directly, ensuring cleaner and more efficient
execution.
