### PR TITLE
feat(cluster): add support for 'generic' cluster type

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -64,7 +64,7 @@ locals {
   }
 
   # Select appropriate configuration based on cluster type
-  provider_config = templatefile(
+  provider_config = var.cluster_type == "generic" ? "" : templatefile(
     local.provider_template[var.cluster_type],
     var.cluster_type == "aws-eks" ? local.aws_config : (
       var.cluster_type == "azure-aks" ? local.azure_config : (

--- a/scripts/setup_truefoundry_cluster.sh
+++ b/scripts/setup_truefoundry_cluster.sh
@@ -208,8 +208,10 @@ main() {
     cluster_id=$(create_cluster "${cluster_manifest}")
     cluster_token=$(get_cluster_token "${cluster_id}")
     
-    # Setup provider account if configured
-    setup_provider_account
+    # Setup provider account if configured and cluster type is not generic
+    if [ "${CLUSTER_TYPE}" != "generic" ]; then
+        setup_provider_account
+    fi
 
     # Get tenant information
     tenant_name=$(get_tenant_name)

--- a/variables.tf
+++ b/variables.tf
@@ -17,10 +17,10 @@ variable "cluster_name" {
 
 variable "cluster_type" {
   type        = string
-  description = "Type of cluster to create (aws-eks, azure-aks, or gcp-gke-standard)"
+  description = "Type of cluster to create (aws-eks, azure-aks, gcp-gke-standard, generic)"
   validation {
-    condition     = contains(["aws-eks", "azure-aks", "gcp-gke-standard"], var.cluster_type)
-    error_message = "cluster_type must be one of: aws-eks, azure-aks, gcp-gke-standard"
+    condition     = contains(["aws-eks", "azure-aks", "gcp-gke-standard", "generic"], var.cluster_type)
+    error_message = "cluster_type must be one of: aws-eks, azure-aks, gcp-gke-standard, generic"
   }
 }
 


### PR DESCRIPTION
Enhance flexibility by allowing a 'generic' cluster type, which
bypasses provider-specific configurations. Update validation and
conditional logic to accommodate this new type, ensuring seamless
integration without provider-specific setup.
