### PR TITLE
feat(terraform): enhance provider integration logic and add IAM role support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ No modules.
 | <a name="input_aws_cluster_integration_enabled"></a> [aws\_cluster\_integration\_enabled](#input\_aws\_cluster\_integration\_enabled) | Enable direct integration with AWS EKS cluster services | `bool` | `true` | no |
 | <a name="input_aws_ecr_enabled"></a> [aws\_ecr\_enabled](#input\_aws\_ecr\_enabled) | Enable AWS Elastic Container Registry (ECR) integration for container image storage | `bool` | `true` | no |
 | <a name="input_aws_parameter_store_enabled"></a> [aws\_parameter\_store\_enabled](#input\_aws\_parameter\_store\_enabled) | Enable AWS Systems Manager Parameter Store integration for secret management | `bool` | `true` | no |
+| <a name="input_aws_platform_features_iam_role_enabled"></a> [aws\_platform\_features\_iam\_role\_enabled](#input\_aws\_platform\_features\_iam\_role\_enabled) | Enable AWS IAM role-based authentication. If true, requires aws\_platform\_features\_role\_arn. | `bool` | `true` | no |
 | <a name="input_aws_platform_features_role_arn"></a> [aws\_platform\_features\_role\_arn](#input\_aws\_platform\_features\_role\_arn) | AWS IAM Role ARN for role-based authentication (e.g., 'arn:aws:iam::123456789012:role/TrueFoundryRole') | `string` | `null` | no |
 | <a name="input_aws_platform_features_user_access_key_id"></a> [aws\_platform\_features\_user\_access\_key\_id](#input\_aws\_platform\_features\_user\_access\_key\_id) | AWS IAM Access Key ID for user-based authentication. Required if aws\_platform\_features\_user\_enabled is true. | `string` | `null` | no |
 | <a name="input_aws_platform_features_user_enabled"></a> [aws\_platform\_features\_user\_enabled](#input\_aws\_platform\_features\_user\_enabled) | Enable AWS IAM user-based authentication. If true, requires aws\_platform\_features\_user\_access\_key\_id and aws\_platform\_features\_user\_secret\_access\_key. | `bool` | `false` | no |
@@ -67,7 +68,7 @@ No modules.
 | <a name="input_gcp_sa_auth_data"></a> [gcp\_sa\_auth\_data](#input\_gcp\_sa\_auth\_data) | GCP Service Account auth\_data | `string` | `null` | no |
 | <a name="input_gcp_secrets_manager_enabled"></a> [gcp\_secrets\_manager\_enabled](#input\_gcp\_secrets\_manager\_enabled) | Enable GCP Secrets Manager integration for secret management | `bool` | `true` | no |
 | <a name="input_gcp_service_account_enabled"></a> [gcp\_service\_account\_enabled](#input\_gcp\_service\_account\_enabled) | Enable GCP Service Account integration for authentication | `bool` | `true` | no |
-| <a name="input_gcp_service_account_key_enabled"></a> [gcp\_service\_account\_key\_enabled](#input\_gcp\_service\_account\_key\_enabled) | Enable GCP Service Account key for authentication | `bool` | n/a | yes |
+| <a name="input_gcp_service_account_key_enabled"></a> [gcp\_service\_account\_key\_enabled](#input\_gcp\_service\_account\_key\_enabled) | Enable GCP Service Account key for authentication | `bool` | `true` | no |
 | <a name="input_gcp_storage_bucket_url"></a> [gcp\_storage\_bucket\_url](#input\_gcp\_storage\_bucket\_url) | URL for GCP Storage bucket (e.g., 'gs://bucket-name') | `string` | `null` | no |
 | <a name="input_stderr_log_file"></a> [stderr\_log\_file](#input\_stderr\_log\_file) | Log file of stdout | `string` | `"truefoundry-cluster.stderr"` | no |
 | <a name="input_stdout_log_file"></a> [stdout\_log\_file](#input\_stdout\_log\_file) | Log file of stdout | `string` | `"truefoundry-cluster.stdout"` | no |
@@ -80,5 +81,6 @@ No modules.
 |------|-------------|
 | <a name="output_cluster_id"></a> [cluster\_id](#output\_cluster\_id) | The ID of the created cluster |
 | <a name="output_cluster_token"></a> [cluster\_token](#output\_cluster\_token) | The token for the cluster |
+| <a name="output_provider_integration_enabled"></a> [provider\_integration\_enabled](#output\_provider\_integration\_enabled) | Whether the provider integration is enabled |
 | <a name="output_tenant_name"></a> [tenant\_name](#output\_tenant\_name) | The name of the tenant |
 <!-- END_TF_DOCS -->

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,8 @@
 locals {
 
-  provider_integration_enabled = var.cluster_type == "gcp-gke-standard" ? var.gcp_service_account_key_enabled && var.gcp_service_account_enabled : true
+  provider_integration_enabled = var.cluster_type == "gcp-gke-standard" ? var.gcp_service_account_key_enabled && var.gcp_service_account_enabled : (
+    var.cluster_type == "aws-eks" ? var.aws_platform_features_iam_role_enabled || var.aws_platform_features_user_enabled : true
+  )
   provider_account_template = {
     "aws-eks"          = "${path.module}/templates/provider-account/aws.json.tpl"
     "azure-aks"        = "${path.module}/templates/provider-account/azure.json.tpl"
@@ -14,10 +16,11 @@ locals {
     cloud_region     = var.aws_region
 
     // Auth related
-    platform_features_user_enabled    = var.aws_platform_features_user_enabled
-    platform_features_user_key_id     = var.aws_platform_features_user_access_key_id
-    platform_features_user_key_secret = var.aws_platform_features_user_secret_access_key
-    platform_features_role_arn        = var.aws_platform_features_role_arn
+    platform_features_user_enabled     = var.aws_platform_features_user_enabled
+    platform_features_user_key_id      = var.aws_platform_features_user_access_key_id
+    platform_features_user_key_secret  = var.aws_platform_features_user_secret_access_key
+    platform_features_iam_role_enabled = var.aws_platform_features_iam_role_enabled
+    platform_features_role_arn         = var.aws_platform_features_role_arn
 
     // Feature flags
     object_store_enabled        = var.aws_s3_enabled

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,3 +13,7 @@ output "cluster_token" {
   value       = local.output_map["CLUSTER_TOKEN"]
   sensitive   = true
 }
+output "provider_integration_enabled" {
+  description = "Whether the provider integration is enabled"
+  value       = local.provider_integration_enabled
+}

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "aws_platform_features_user_enabled" {
   description = "Enable AWS IAM user-based authentication. If true, requires aws_platform_features_user_access_key_id and aws_platform_features_user_secret_access_key."
   default     = false
 }
+variable "aws_platform_features_iam_role_enabled" {
+  type        = bool
+  description = "Enable AWS IAM role-based authentication. If true, requires aws_platform_features_role_arn."
+  default     = true
+}
 
 variable "aws_platform_features_user_access_key_id" {
   type        = string
@@ -234,6 +239,7 @@ variable "gcp_service_account_key_enabled" {
   type        = bool
   description = "Enable GCP Service Account key for authentication"
   sensitive   = true
+  default     = true
 }
 
 variable "gcp_storage_bucket_url" {


### PR DESCRIPTION
- Updated `provider_integration_enabled` logic to include support for AWS IAM role-based authentication.
- Introduced a new variable `aws_platform_features_iam_role_enabled` to manage IAM role integration.
- Added output for `provider_integration_enabled` to provide visibility on integration status.

These changes improve the flexibility and configurability of provider integrations across different cloud environments.
