### PR TITLE
feat: stop sending hardcoded cluster collaborators (INFRA-1181)

### DIFF
--- a/.github/workflows/tofu-test.yaml
+++ b/.github/workflows/tofu-test.yaml
@@ -1,0 +1,31 @@
+name: OpenTofu Test
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tofu-test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        tofu_version:
+          - "1.10.0"
+          - "1.11.0"
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Setup OpenTofu ${{ matrix.tofu_version }}
+        uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_version: ${{ matrix.tofu_version }}
+
+      - name: Tofu init
+        run: tofu init -backend=false
+
+      - name: Tofu test
+        run: tofu test -verbose

--- a/.github/workflows/tofu-test.yaml
+++ b/.github/workflows/tofu-test.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup OpenTofu ${{ matrix.tofu_version }}
         uses: opentofu/setup-opentofu@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Local .terraform directories
 **/.terraform/*
 
+# Dependency lock file (not committed for reusable modules)
+.terraform.lock.hcl
+**/.terraform.lock.hcl
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,6 @@ output "cluster_token" {
 }
 output "provider_integration_enabled" {
   description = "Whether the provider integration is enabled"
-  value       = local.provider_integration_enabled
+  # Unwrap: sensitivity is inherited from a gcp var via the locals ternary; value is just a bool flag.
+  value = nonsensitive(local.provider_integration_enabled)
 }

--- a/templates/cluster/aws.json.tpl
+++ b/templates/cluster/aws.json.tpl
@@ -2,12 +2,6 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
-    "collaborators": [
-        {
-        "role_id": "cluster-admin",
-        "subject": "user:tfy-user@truefoundry.com"
-        }
-    ],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if provider_integration_enabled }

--- a/templates/cluster/aws.json.tpl
+++ b/templates/cluster/aws.json.tpl
@@ -2,6 +2,7 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
+    "collaborators": [],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if provider_integration_enabled }

--- a/templates/cluster/azure.json.tpl
+++ b/templates/cluster/azure.json.tpl
@@ -2,12 +2,6 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
-    "collaborators": [
-        {
-        "role_id": "cluster-admin",
-        "subject": "user:tfy-user@truefoundry.com"
-        }
-    ],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if container_registry_enabled },

--- a/templates/cluster/azure.json.tpl
+++ b/templates/cluster/azure.json.tpl
@@ -2,6 +2,7 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
+    "collaborators": [],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if container_registry_enabled },

--- a/templates/cluster/gcp.json.tpl
+++ b/templates/cluster/gcp.json.tpl
@@ -2,12 +2,6 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
-    "collaborators": [
-        {
-        "role_id": "cluster-admin",
-        "subject": "user:tfy-user@truefoundry.com"
-        }
-    ],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if provider_integration_enabled }

--- a/templates/cluster/gcp.json.tpl
+++ b/templates/cluster/gcp.json.tpl
@@ -2,6 +2,7 @@
     "manifest": {
     "name": "${cluster_name}",
     "type": "cluster",
+    "collaborators": [],
     "cluster_type": "${cluster_type}",
     "environment_names": ["${env_name}"]
     %{ if provider_integration_enabled }

--- a/tests/cluster_manifest.tftest.hcl
+++ b/tests/cluster_manifest.tftest.hcl
@@ -1,0 +1,137 @@
+# INFRA-1181: the cluster manifest must NOT carry a hardcoded `collaborators` block.
+# Server PR #10092 dropped the requirement for a cluster-admin collaborator; this module
+# previously hardcoded `user:tfy-user@truefoundry.com`, which left a stray cluster-admin
+# role-binding on every provisioned cluster.
+#
+# Plan-only. The two `data "external"` sources run shell scripts (get_environment hits the
+# control-plane API, create_cluster PUTs the manifest), so both are stubbed via override_data —
+# no scripts, no network. Assertions parse the rendered `local.cluster_config` with jsondecode.
+# Provider feature flags are forced off so the sibling provider-account template renders without
+# null interpolations; the cluster manifest under test is unaffected.
+
+mock_provider "external" {}
+
+variables {
+  aws_s3_enabled                    = false
+  aws_ecr_enabled                   = false
+  aws_parameter_store_enabled       = false
+  aws_secrets_manager_enabled       = false
+  aws_cluster_integration_enabled   = false
+  gcp_container_registry_enabled    = false
+  gcp_blob_storage_enabled          = false
+  gcp_secrets_manager_enabled       = false
+  gcp_cluster_integration_enabled   = false
+  azure_acr_enabled                 = false
+  azure_blob_storage_enabled        = false
+  azure_cluster_integration_enabled = false
+}
+
+override_data {
+  target = data.external.get_environment
+  values = {
+    result = {
+      environment_name = "test-env"
+      tenant_name      = "test-tenant"
+    }
+  }
+}
+
+override_data {
+  target = data.external.create_cluster
+  values = {
+    result = {
+      cluster_id    = "cluster-test-id"
+      cluster_token = "cluster-test-token"
+    }
+  }
+}
+
+run "aws_manifest_has_no_collaborators" {
+  command = plan
+
+  variables {
+    control_plane_url              = "https://example.test"
+    tfy_api_key                    = "test.test.test"
+    cluster_name                   = "tfy-smoke-aws"
+    cluster_type                   = "aws-eks"
+    aws_account_id                 = "123456789012"
+    aws_region                     = "us-east-1"
+    aws_platform_features_role_arn = "arn:aws:iam::123456789012:role/tfy"
+  }
+
+  assert {
+    condition     = can(jsondecode(local.cluster_config))
+    error_message = "Rendered aws cluster manifest is not valid JSON"
+  }
+
+  assert {
+    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
+    error_message = "aws cluster manifest must not contain a collaborators key"
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_config).manifest.name == var.cluster_name
+    error_message = "aws manifest name should equal var.cluster_name"
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_config).manifest.cluster_type == "aws-eks"
+    error_message = "aws manifest cluster_type should be aws-eks"
+  }
+}
+
+run "gcp_manifest_has_no_collaborators" {
+  command = plan
+
+  variables {
+    control_plane_url = "https://example.test"
+    tfy_api_key       = "test.test.test"
+    cluster_name      = "tfy-smoke-gcp"
+    cluster_type      = "gcp-gke-standard"
+    gcp_project_id    = "tfy-test-project"
+    gcp_region        = "us-central1"
+    gcp_sa_auth_data  = "{}"
+  }
+
+  assert {
+    condition     = can(jsondecode(local.cluster_config))
+    error_message = "Rendered gcp cluster manifest is not valid JSON"
+  }
+
+  assert {
+    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
+    error_message = "gcp cluster manifest must not contain a collaborators key"
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_config).manifest.cluster_type == "gcp-gke-standard"
+    error_message = "gcp manifest cluster_type should be gcp-gke-standard"
+  }
+}
+
+run "azure_manifest_has_no_collaborators" {
+  command = plan
+
+  variables {
+    control_plane_url     = "https://example.test"
+    tfy_api_key           = "test.test.test"
+    cluster_name          = "tfy-smoke-azure"
+    cluster_type          = "azure-aks"
+    azure_subscription_id = "00000000-0000-0000-0000-000000000000"
+  }
+
+  assert {
+    condition     = can(jsondecode(local.cluster_config))
+    error_message = "Rendered azure cluster manifest is not valid JSON"
+  }
+
+  assert {
+    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
+    error_message = "azure cluster manifest must not contain a collaborators key"
+  }
+
+  assert {
+    condition     = jsondecode(local.cluster_config).manifest.cluster_type == "azure-aks"
+    error_message = "azure manifest cluster_type should be azure-aks"
+  }
+}

--- a/tests/cluster_manifest.tftest.hcl
+++ b/tests/cluster_manifest.tftest.hcl
@@ -1,7 +1,8 @@
-# INFRA-1181: the cluster manifest must NOT carry a hardcoded `collaborators` block.
+# INFRA-1181: the cluster manifest must send an EMPTY `collaborators` list.
 # Server PR #10092 dropped the requirement for a cluster-admin collaborator; this module
 # previously hardcoded `user:tfy-user@truefoundry.com`, which left a stray cluster-admin
-# role-binding on every provisioned cluster.
+# role-binding on every provisioned cluster. The key stays required by the manifest schema
+# (empty array is valid), so we send [] rather than omitting it.
 #
 # Plan-only. The two `data "external"` sources run shell scripts (get_environment hits the
 # control-plane API, create_cluster PUTs the manifest), so both are stubbed via override_data —
@@ -65,8 +66,8 @@ run "aws_manifest_has_no_collaborators" {
   }
 
   assert {
-    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
-    error_message = "aws cluster manifest must not contain a collaborators key"
+    condition     = jsondecode(local.cluster_config).manifest.collaborators == []
+    error_message = "aws cluster manifest collaborators must be an empty list"
   }
 
   assert {
@@ -99,8 +100,8 @@ run "gcp_manifest_has_no_collaborators" {
   }
 
   assert {
-    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
-    error_message = "gcp cluster manifest must not contain a collaborators key"
+    condition     = jsondecode(local.cluster_config).manifest.collaborators == []
+    error_message = "gcp cluster manifest collaborators must be an empty list"
   }
 
   assert {
@@ -126,8 +127,8 @@ run "azure_manifest_has_no_collaborators" {
   }
 
   assert {
-    condition     = lookup(jsondecode(local.cluster_config).manifest, "collaborators", null) == null
-    error_message = "azure cluster manifest must not contain a collaborators key"
+    condition     = jsondecode(local.cluster_config).manifest.collaborators == []
+    error_message = "azure cluster manifest collaborators must be an empty list"
   }
 
   assert {


### PR DESCRIPTION
Removes the hardcoded tfy-user cluster-admin collaborator from aws/gcp/azure cluster manifest templates (server PR #10092 dropped the requirement). Adds tofu test coverage + tofu-test.yaml CI (module had none). Wraps output provider_integration_enabled in nonsensitive() to unblock tofu test. tofu test: 3 passed. Ref INFRA-1181, follow-up to INFRA-1161.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster manifest RBAC sent to the control plane on create/update; behavior is intentional but affects every newly provisioned cluster until rolled out.
> 
> **Overview**
> Stops provisioning clusters with a hardcoded **cluster-admin** collaborator (`user:tfy-user@truefoundry.com`) by setting **`collaborators` to `[]`** in the AWS, GCP, and Azure cluster manifest templates, matching the control-plane change that no longer requires that binding.
> 
> Adds **OpenTofu test** coverage (`tests/cluster_manifest.tftest.hcl`) that plan-stubs external data sources and asserts rendered manifests are valid JSON with an empty `collaborators` list per cloud. Introduces a **PR workflow** (`.github/workflows/tofu-test.yaml`) running `tofu init -backend=false` and `tofu test` on OpenTofu **1.10.0** and **1.11.0**.
> 
> **`provider_integration_enabled`** output is wrapped in **`nonsensitive()`** so plan/tests are not blocked by inherited sensitivity from GCP locals. **`.terraform.lock.hcl`** is added to **`.gitignore`** for this reusable module layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b158fa78b4ee15344a44d4a9d93fb99404310bd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->